### PR TITLE
Fix CTypes::Struct#pretty_inspect for CTypes::Pad

### DIFF
--- a/lib/ctypes/struct.rb
+++ b/lib/ctypes/struct.rb
@@ -515,6 +515,7 @@ module CTypes
         q.seplist(self.class.field_layout, -> { q.breakable("") }) do |name, _|
           names = name.is_a?(::Array) ? name : [name]
           names.each do |name|
+            next if name.is_a?(CTypes::Pad)
             q.text(".#{name} = ")
             q.pp(instance_variable_get(:"@#{name}"))
             q.text(", ")

--- a/lib/ctypes/version.rb
+++ b/lib/ctypes/version.rb
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: MIT
 
 module CTypes
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Struct#pretty_inspect was failing when printing CTypes::Pad struct members.  Fixed in this commit.