### PR TITLE
Struct#pretty_print strip blank lines 

### DIFF
--- a/lib/ctypes/struct.rb
+++ b/lib/ctypes/struct.rb
@@ -512,8 +512,11 @@ module CTypes
         "struct {"
       end
       q.group(4, open, "}") do
-        q.seplist(self.class.field_layout, -> { q.breakable("") }) do |name, _|
-          names = name.is_a?(::Array) ? name : [name]
+        # strip out pad fields
+        fields = self.class.field_layout.reject do |(_, type)|
+          type.is_a?(CTypes::Pad)
+        end
+        q.seplist(fields, -> { q.breakable("") }) do |name, _|
           names.each do |name|
             next if name.is_a?(CTypes::Pad)
             q.text(".#{name} = ")

--- a/lib/ctypes/struct.rb
+++ b/lib/ctypes/struct.rb
@@ -515,6 +515,7 @@ module CTypes
         q.seplist(self.class.field_layout, -> { q.breakable("") }) do |name, _|
           names = name.is_a?(::Array) ? name : [name]
           names.each do |name|
+            next if name.is_a?(CTypes::Pad)
             q.text(".#{name} = ")
             q.pp(instance_variable_get(:"@#{name}"))
             q.text(", ")

--- a/lib/ctypes/version.rb
+++ b/lib/ctypes/version.rb
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: MIT
 
 module CTypes
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/ctypes/version.rb
+++ b/lib/ctypes/version.rb
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: MIT
 
 module CTypes
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
The previous fix resolved the error during inspect, but left blank lines
in the output for pad fields.  This commit removes those blank lines.