### PR TITLE
extend Helpers into CTypes, Enum#[] symbol support

### DIFF
--- a/lib/ctypes/bitfield.rb
+++ b/lib/ctypes/bitfield.rb
@@ -94,7 +94,7 @@ module CTypes
 
     # get the size of the bitfield in bytes
     def self.size
-      @type.size
+      @type&.size
     end
 
     # check if bitfield is a fixed size

--- a/lib/ctypes/enum.rb
+++ b/lib/ctypes/enum.rb
@@ -185,15 +185,26 @@ module CTypes
       Enum.new(@type, @dry_type.mapping, permissive: true)
     end
 
-    # lookup the key for a given Integer value in this Enum
+    # Convert a enum key to value, or value to key
+    # @param arg [Integer, Symbol] key or value
+    # @return [Symbol, Integer, nil] value or key if known, nil if unknown
     #
     # @example
     #   e = Enum.new(%i[a b c])
     #   e[1]    # => :b
     #   e[5]    # => nil
-    def [](value)
-      @inverted_mapping ||= @dry_type.mapping.invert
-      @inverted_mapping[value]
+    #   e[:b]   # => 1
+    #   e[:x]   # => nil
+    def [](arg)
+      case arg
+      when Integer
+        @inverted_mapping ||= @dry_type.mapping.invert
+        @inverted_mapping[arg]
+      when Symbol
+        @dry_type.mapping[arg]
+      else
+        raise ArgumentError, "arg must be Integer or Symbol: %p" % [arg]
+      end
     end
   end
 end

--- a/lib/ctypes/helpers.rb
+++ b/lib/ctypes/helpers.rb
@@ -187,4 +187,10 @@ module CTypes
       end
     end
   end
+
+  # To make CTypes easier to use without including Helpers everywhere, we're
+  # going to extend Helpers into the CTypes namespace.  This is to support
+  # interactive sessions through pry/irb where you need to quickly create types
+  # without having to constantly type out `Helpers`.
+  CTypes.extend(Helpers)
 end

--- a/lib/ctypes/version.rb
+++ b/lib/ctypes/version.rb
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: MIT
 
 module CTypes
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/spec/ctypes/enum_spec.rb
+++ b/spec/ctypes/enum_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CTypes::Enum do
   end
 
   context "#[]" do
-    it "will return the Symbol for a valid value" do
+    it "will return the Symbol for a known value" do
       e = described_class.new(%i[a b c])
       expect(e[1]).to eq(:b)
     end
@@ -128,6 +128,16 @@ RSpec.describe CTypes::Enum do
     it "will return nil for an unknown value" do
       e = described_class.new(%i[a b c])
       expect(e[100]).to be_nil
+    end
+
+    it "will return the value for a known Symbol" do
+      e = described_class.new({x: 0x1000})
+      expect(e[:x]).to eq(0x1000)
+    end
+
+    it "will return nil for an unknown Symbol" do
+      e = described_class.new(%i[a b c])
+      expect(e[:unknown]).to be_nil
     end
   end
 end


### PR DESCRIPTION
* Extended CTypes::Helpers into CTypes to reduce typing required in irb/pry when using types interactively
* Update Enum#[] to lookup value by name
* Fix bug in Bitfield.size that broke pry `ls` command
* version minor bump for new functionality